### PR TITLE
Update VERSION_RELAY_EXTENSION to 0.20.0

### DIFF
--- a/runtime/base/Dockerfile
+++ b/runtime/base/Dockerfile
@@ -513,7 +513,7 @@ RUN set -xe; \
 # Needed by:
 #   - php
 ENV RELAY_BUILD_DIR=${BUILD_DIR}/relay
-ENV VERSION_RELAY_EXTENSION=0.12.1
+ENV VERSION_RELAY_EXTENSION=0.20.0
 
 # Install some dev files for using old libraries already on the system
 # readline-devel : needed for the --with-libedit flag


### PR DESCRIPTION
See https://github.com/cachewerk/relay/releases/tag/v0.20.0

@carlalexander Should we make the build process always pick the latest stable version?